### PR TITLE
Tools menu

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,14 @@ install_requires =
     qtpy
     n2v>=0.3.1
     bioimageio.core
-    pyqtgraph,
-    napari_time_slicer
+    pyqtgraph
+    napari_time_slicer >= 0.4.9
+    napari_tools_menu >= 0.1.17
+    # pin napari and vispy because
+    # https://github.com/napari/napari/issues/4415
+    # https://github.com/napari/napari/issues/4708
+    napari<=0.4.15
+    vispy<=0.9.6
 
 
 [options.extras_require]
@@ -64,3 +70,5 @@ where = src
 [options.entry_points]
 napari.manifest =
     napari-n2v = napari_n2v:napari.yaml
+napari.plugin =
+    napari-n2v2 = napari_n2v.utils.n2v_utils

--- a/src/napari_n2v/utils/prediction_worker.py
+++ b/src/napari_n2v/utils/prediction_worker.py
@@ -35,7 +35,7 @@ def apply_n2v(image: "napari.types.ImageData",
         raise Exception('Model not found')
 
     # load the model
-    model = load_model
+    model = load_model(model_path)
 
     # check image shape
     if len(image.shape) == 2:

--- a/src/napari_n2v/utils/prediction_worker.py
+++ b/src/napari_n2v/utils/prediction_worker.py
@@ -8,6 +8,7 @@ from tensorflow.python.framework.errors_impl import UnknownError
 from tifffile import imwrite
 from napari.qt.threading import thread_worker
 from napari.utils import notifications as ntf
+from magicgui.types import PathLike
 
 from napari_n2v.utils import (
     UpdateType,
@@ -25,7 +26,7 @@ from napari_time_slicer import time_slicer
 @register_function(menu="Filtering / noise removal > Apply N2V denoiser")
 @time_slicer
 def apply_n2v(image: "napari.types.ImageData",
-              model_filename: str = "my_n2v_model",
+              model_filename: PathLike = "my_n2v_model",
               number_of_tiles: int = 4,
               ) -> "napari.types.ImageData":
     """


### PR DESCRIPTION
Hi Joran @jdeschamps ,

here comes a PR for making the denoising work from the Assistant / Tools menu as discussed here:
* https://github.com/juglab/napari-n2v/issues/6

Some things here are optional, but step by step:

* You should at least take over this change which was necessary to make the function work:

https://github.com/haesleinhuepf/napari-n2v/blob/d93c9fb54d9a473ac64ad8e43035d4cf673733be/src/napari_n2v/utils/prediction_worker.py#L39

* I changed the `model_filename` parameter from type `str` to `PathLike` which adds the `Select File` button to the generated GUI:

![image](https://user-images.githubusercontent.com/12660498/193516014-73a936e1-5c2a-4e1b-9c5a-efa94a564987.png)

This change avoids the denoiser being shown in the assistant at the moment. I will fix this on the Assistant side: https://github.com/haesleinhuepf/napari-assistant/issues/34

* A little warning: The `register_function` needs `napari_tools_menu`, which was not in the requirements:

https://github.com/haesleinhuepf/napari-n2v/blob/d93c9fb54d9a473ac64ad8e43035d4cf673733be/src/napari_n2v/utils/prediction_worker.py#L22

https://github.com/haesleinhuepf/napari-n2v/blob/d93c9fb54d9a473ac64ad8e43035d4cf673733be/setup.cfg#L46

* Now comes the optional part: The napari-tools-menu is only compatible with napari <= 0.4.15 ([See also](https://github.com/napari/napari/issues/4708)). That's why these changes are necessary: 

https://github.com/haesleinhuepf/napari-n2v/blob/d93c9fb54d9a473ac64ad8e43035d4cf673733be/setup.cfg#L47-L51

There is an alternative: You could remove the dependency to napari-tools-menu as proposed in this PR:
* https://github.com/haesleinhuepf/napari-n2v/pull/1

However, let me pitch the tools menu for a moment. We know well that users are confused from the plugins menu. It is hard to find things there because of its chaotic ordering:

![image](https://user-images.githubusercontent.com/12660498/193516973-e6af072c-f2ff-4ecc-9afd-4c742b144b50.png)

I'm claiming that functionality is easier to find the Tools menu:

![image](https://user-images.githubusercontent.com/12660498/193517047-fe37f0cb-15bc-4b00-8a57-30b7cc74f046.png)

The drawback is pinning napari<=0.4.15 . It comes with the advantage though that updates to napari-core cannot break our plugins 🌞 

Let me know what you think!

Best,
Robert
