### PR TITLE
Tweak to macOS instructions and add back tensorflow-metal

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,7 +28,7 @@ operating system.
 
 1. Set up env with napari and pyqt5
    ```bash
-      conda create -n napari-n2v -c conda-forge python=3.9 napari pyqt5 imagecodecs
+      conda create -n napari-n2v -c conda-forge python=3.9 pyqt imagecodecs napari=0.4.15
    ```
 2. Install tensorflow following [Apple's instructions](https://developer.apple.com/metal/tensorflow-plugin/)
 3. Install napari-n2v

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ install_requires =
     # tensorflow
     tensorflow;  platform_system!="Darwin" or platform_machine!="arm64"
     tensorflow-macos;  platform_system=="Darwin" and platform_machine=="arm64"
+    tensorflow-metal;  platform_system=="Darwin" and platform_machine=="arm64"
 
 [options.extras_require]
 testing =


### PR DESCRIPTION
It's probably due to my typos earlier, but on conda-forge pyqt5 is just pyqt. This fixes that. Plus sets the version to 0.4.15 because you pin it.
Also, on arm64 tensorflow-metal is really worthwhile, so I add that back with the same darwin/arm64 restriction. I can't see any reason not to just pull it.