### PR TITLE
fix bioimageio test failiure on windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ omit =
 
 [testenv]
 passenv =
+    USERNAME
     CI
     GITHUB_ACTIONS
     DISPLAY_XAUTHORITY
@@ -20,4 +21,4 @@ passenv =
 extras =
     testing
 commands =
-    pytest -v --cov=napari_n2v --cov-report=xml -m "not qt and not bioimage_io"
+    pytest -v --cov=napari_n2v --cov-report=xml -m "not qt"


### PR DESCRIPTION
Pass USERNAME in tox.ini to fix bioimageio test failure on windows